### PR TITLE
V4.3.5 Update

### DIFF
--- a/Afflictions.xml
+++ b/Afflictions.xml
@@ -430,6 +430,16 @@
 
   <!--CBRN Gears-->
   <Affliction identifier="APR" type="CBRNGEAR" IsBuff="true" targets="human" showiconthreshold="999" showinhealthscannerthreshold="999" maxstrength="10" limbspecific="false" indicatorlimb="Head" Duration="0.1">
+    <Effect minstrength="0" maxstrength="10" maxvitalitydecrease="0" strengthchange="0" resistancefor="airagent,oxygenlow" minresistance="100.0" maxresistance="100.0">
+	  <StatusEffect target="Character" disabledeltatime="true">
+        <ReduceAffliction type="airagent" amount="99999" />
+        <ReduceAffliction type="oxygenlow" amount="99999" />
+      </StatusEffect>
+	  </Effect>
+    <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="0,0,1,1" color="0,0,0,255" origin="0,0" />
+    <!--Status Affliction-->
+  </Affliction>
+  <Affliction identifier="APR_M" type="CBRNGEAR" IsBuff="true" targets="human" showiconthreshold="999" showinhealthscannerthreshold="999" maxstrength="10" limbspecific="false" indicatorlimb="Head" Duration="0.1">
     <Effect minstrength="0" maxstrength="10" maxvitalitydecrease="0" strengthchange="0" resistancefor="airagent" minresistance="100.0" maxresistance="100.0">
 	  <StatusEffect target="Character" disabledeltatime="true">
         <ReduceAffliction type="airagent" amount="99999" />

--- a/Job/AfflictionsCBRN.xml
+++ b/Job/AfflictionsCBRN.xml
@@ -6,14 +6,16 @@
     isbuff="true"
     hideiconafterdelay="true"
     limbspecific="false"
-    maxstrength="20"
-    stackable="false"
+    maxstrength="10"
     treatmentthreshold="1000"
+    duration="10"
     iconcolors="33,75,78;126,211,224;126,211,224;227,247,249">
-    <Effect minstrength="0" maxstrength="20" strengthchange="-1">
+    <Effect minstrength="0" maxstrength="15">
+      <StatValue stattype="AttackMultiplier" value="0.25" />
       <AbilityFlag flagtype="AlwaysStayConscious" />
+      <AbilityFlag flagtype="CanNotDieToAfflictions" />
     </Effect>
-    <Icon texture="Content/UI/TalentsIcons4.png" sheetindex="6,1" sheetelementsize="128,128" color="10,193,114,255" origin="0,0"/>
+    <Icon texture="Content/UI/TalentsIcons3.png" sheetindex="0,0" sheetelementsize="128,128" color="10,193,114,255" origin="0,0"/>
   </Affliction>
 
   <Affliction

--- a/Job/TalentsCBRN.xml
+++ b/Job/TalentsCBRN.xml
@@ -65,7 +65,7 @@
       <Replace tag="[rangeamount]" value="10" color="gui.green"/>
       <Replace tag="[damageamount]" value="10" color="gui.green"/>
     </Description>
-    <Icon texture="Content/UI/TalentsIcons4.png" sheetindex="4,4" sheetelementsize="128,128"/>
+    <Icon texture="Content/UI/TalentsIcons2.png" sheetindex="3,3" sheetelementsize="128,128"/>
     <AbilityGroupEffect abilityeffecttype="None">
       <Abilities>
         <CharacterAbilityGiveStat stattype="ExplosionRadiusMultiplier" value="0.1"/>
@@ -93,9 +93,12 @@
     </AbilityGroupInterval>
   </Talent>
   <Talent identifier="dutyofcbrn">
-    <Description tag="talentdescription.dutyofcbrn">
-    <Replace tag="[affliction2]" value="afflictionname.adrenalinerush" color="gui.blue"/>
-    <Replace tag="[time]" value="20" color="gui.green"/>
+    <Description tag="talentdescription.dutyofcbrn"><!--Change needed-->
+      <Replace tag="[affliction1]" value="afflictionname.adrenalinerush" color="gui.blue"/>
+      <Replace tag="[cd1]" value="60s" color="gui.green"/>
+      <Replace tag="[affliction2]" value="afflictionname.combatstimulant" color="gui.blue"/>
+      <Replace tag="[cd2]" value="5s" color="gui.green"/>
+      <Replace tag="[time]" value="10" color="gui.green"/>
     </Description>
     <Description tag="talentdescription.maxtriggeruntildeath"/>
     <Icon texture="Content/UI/TalentsIcons1.png" sheetindex="7,2" sheetelementsize="128,128"/>
@@ -107,7 +110,7 @@
         <CharacterAbilityApplyStatusEffects>
           <StatusEffects>
             <StatusEffect type="OnAbility" target="Character" multiplyafflictionsbymaxvitality="true" disabledeltatime="true" >
-              <Affliction identifier="dutyofcbrn" amount="15.0"/>
+              <Affliction identifier="dutyofcbrn" amount="10.0"/>
             </StatusEffect>
           </StatusEffects>
         </CharacterAbilityApplyStatusEffects>
@@ -117,8 +120,11 @@
       <Abilities>
         <CharacterAbilityApplyStatusEffects>
           <StatusEffects>
-            <StatusEffect type="OnAbility" target="This" multiplyafflictionsbymaxvitality="true">
-              <Affliction identifier="adrenalinerush" amount="20.0"/>
+            <StatusEffect type="OnAbility" target="This" multiplyafflictionsbymaxvitality="false" Interval="30">
+              <Affliction identifier="adrenalinerush" amount="10.0"/>
+            </StatusEffect>
+            <StatusEffect type="OnAbility" target="This" multiplyafflictionsbymaxvitality="false" Interval="5">
+              <Affliction identifier="combatstimulant" amount="5.0"/>
             </StatusEffect>
           </StatusEffects>
         </CharacterAbilityApplyStatusEffects>
@@ -198,7 +204,7 @@
       <Replace tag="[itemname]" value="entityname.berra_m4_beowulf,entityname.berra_m110" color="gui.orange"/>
     </Description>
     <Description tag="talentdescription.unlockrecipe">
-      <Replace tag="[itemname]" value="talentvalue.berra_STANAG_50beowulf_fr,talentvalue.berra_STANAG_458socom_ext,talentvalue.berra_300FAL_M118LR" color="gui.orange"/>
+      <Replace tag="[itemname]" value="talentvalue.berra_STANAG_50beowulf_fr,talentvalue.berra_STANAG_50beowulf_ap,talentvalue.berra_STANAG_458socom_ext,talentvalue.berra_300FAL_M118LR" color="gui.orange"/>
     </Description>
     <Description tag="talentdescription.unlockrecipe">
       <Replace tag="[itemname]" value="entityname.berra_bio2,entityname.berra_cbrn3a" color="gui.orange"/>
@@ -211,6 +217,7 @@
     <AddedRecipe itemidentifier="berra_m4_beowulf"/>
     <AddedRecipe itemidentifier="berra_m110"/>
     <AddedRecipe itemidentifier="berra_STANAG_50beowulf_fr"/>
+    <AddedRecipe itemidentifier="berra_STANAG_50beowulf_ap"/>
     <AddedRecipe itemidentifier="berra_STANAG_458socom_ext"/>
     <AddedRecipe itemidentifier="berra_300FAL_M118LR"/>
     <AddedRecipe itemidentifier="berra_bio2"/>
@@ -270,10 +277,10 @@
       <Replace tag="[itemname]" value="entityname.berra_m82a1,entityname.berra_m107a1,entityname.berra_m107a1_fa" color="gui.orange"/>
     </Description>
     <Description tag="talentdescription.unlockrecipe">
-      <Replace tag="[itemname]" value="talentvalue.berra_M107Mag_m33,talentvalue.berra_M107Mag_m1022" color="gui.orange"/>
+      <Replace tag="[itemname]" value="talentvalue.berra_M107Mag_m33,talentvalue.berra_M107Mag_m1022,talentvalue.berra_M107Mag_m903,talentvalue.berra_M107Mag_mk211mod0" color="gui.orange"/>
     </Description>
     <Description tag="talentdescription.unlockrecipe">
-      <Replace tag="[itemname]" value="talentvalue.berra_STANAG_50beowulf_ap,talentvalue.berra_STANAG_50beowulf_fr_ext" color="gui.orange"/>
+      <Replace tag="[itemname]" value="talentvalue.berra_STANAG_50beowulf_ap_ext,talentvalue.berra_STANAG_50beowulf_fr_ext,talentvalue.berra_STANAG_50beowulf_fr_drum" color="gui.orange"/>
     </Description>
     <AddedRecipe itemidentifier="berra_m82a1"/>
     <AddedRecipe itemidentifier="berra_m107a1"/>
@@ -282,8 +289,9 @@
     <AddedRecipe itemidentifier="berra_M107Mag_m1022"/>
     <AddedRecipe itemidentifier="berra_M107Mag_m903"/>
     <AddedRecipe itemidentifier="berra_M107Mag_mk211mod0"/>
-    <AddedRecipe itemidentifier="berra_STANAG_50beowulf_ap"/>
+    <AddedRecipe itemidentifier="berra_STANAG_50beowulf_ap_ext"/>
     <AddedRecipe itemidentifier="berra_STANAG_50beowulf_fr_ext"/>
+    <AddedRecipe itemidentifier="berra_STANAG_50beowulf_fr_drum"/>
   </Talent>
 
   <Talent identifier="biodev">
@@ -312,16 +320,15 @@
     </AbilityGroupEffect>
   </Talent>
   <Talent identifier="reviscomming">
-    <Description tag="talentdescription.skillbonus">
-      <Replace tag="[amount]" value="30" color="gui.green"/>
-      <Replace tag="[skillname]" value="skillname.weapons" color="gui.orange"/>
+    <Description tag="talentdescription.crafthighqualityweapons">
+      <Replace tag="[qualitybonus]" value="1" color="gui.green"/>
     </Description>
     <Description tag="talentdescription.reviscomming_main">
       <Replace tag="[revammo]" value="talentvalue.reviscomming_item" color="255,0,0,255"/>
     </Description>
     <AbilityGroupEffect abilityeffecttype="None">
       <Abilities>
-        <CharacterAbilityGiveStat stattype="WeaponsSkillBonus" value="30"/>
+        <CharacterAbilityGivePermanentStat statidentifier="weapon" stattype="IncreaseFabricationQuality" value="1" />
       </Abilities>
     </AbilityGroupEffect>
     <AddedRecipe itemidentifier="fkj_545_mag_rev"/>

--- a/Weapons/Magazine/Magazines.xml
+++ b/Weapons/Magazine/Magazines.xml
@@ -892,8 +892,8 @@
       <Price storeidentifier="merchantmine" multiplier="1.25" />
     </Price>
     <Deconstruct time="18">
-      <Item identifier="plastic" outcondition="0.7" />
-      <Item identifier="flashpowder" mincondition="0.6" outcondition="0.6" />
+      <Item identifier="plastic" outcondition="0.5" />
+      <Item identifier="flashpowder" mincondition="0.6" outcondition="0.5" />
       <Item identifier="copper" mincondition="0.8" amount="1" />
     </Deconstruct>
     <Fabricate suitablefabricators="fabricator" requiredtime="35" displayname="50beowulf_fr" requiresrecipe="true">
@@ -934,7 +934,7 @@
       <Price storeidentifier="merchantmine" multiplier="1.25" />
     </Price>
     <Deconstruct time="18">
-      <Item identifier="plastic" outcondition="0.7" />
+      <Item identifier="plastic" outcondition="0.5" />
       <Item identifier="flashpowder" mincondition="0.8" amount="1" />
       <Item identifier="titanium" mincondition="0.8" amount="1" />
     </Deconstruct>
@@ -943,7 +943,7 @@
       <RequiredItem identifier="magnesium" amount="2" />
       <RequiredItem identifier="flashpowder" amount="1" />
       <RequiredItem identifier="titanium" amount="5" />
-    <RequiredItem identifier="plastic" />
+      <RequiredItem identifier="plastic" />
     </Fabricate>
     <Fabricate suitablefabricators="fabricator" requiredtime="35" displayname="50beowulf_ap_recycle" requiresrecipe="true">
       <RequiredSkill identifier="weapons" level="40" />
@@ -974,9 +974,9 @@
       <Price storeidentifier="merchantmine" multiplier="1.25" />
     </Price>
     <Deconstruct time="18">
-      <Item identifier="plastic" outcondition="0.7" />
-      <Item identifier="flashpowder" mincondition="0.8" outcondition="0.6" />
-      <Item identifier="copper" mincondition="0.8" amount="1" />
+      <Item identifier="plastic" outcondition="0.5" />
+      <Item identifier="flashpowder" mincondition="0.8" amount="2" />
+      <Item identifier="copper" mincondition="0.8" amount="2" />
     </Deconstruct>
     <Fabricate suitablefabricators="fabricator" requiredtime="35" displayname="50beowulf_fr" requiresrecipe="true">
       <RequiredSkill identifier="weapons" level="40" />
@@ -1016,10 +1016,24 @@
       <Price storeidentifier="merchantmine" multiplier="1.25" />
     </Price>
     <Deconstruct time="18">
-      <Item identifier="plastic" outcondition="0.7" />
-      <Item identifier="flashpowder" mincondition="0.8" outcondition="0.6" />
-      <Item identifier="titanium" mincondition="0.8" amount="1" />
+      <Item identifier="plastic" outcondition="0.5" />
+      <Item identifier="flashpowder" mincondition="0.8" amount="2" />
+      <Item identifier="titanium" mincondition="0.8" amount="2" />
     </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="35" displayname="50beowulf_ap" requiresrecipe="true">
+      <RequiredSkill identifier="weapons" level="60" />
+      <RequiredItem identifier="magnesium" amount="4" />
+      <RequiredItem identifier="flashpowder" amount="2" />
+      <RequiredItem identifier="titanium" amount="8" />
+      <RequiredItem identifier="plastic" />
+    </Fabricate>
+    <Fabricate suitablefabricators="fabricator" requiredtime="35" displayname="50beowulf_ap_recycle" requiresrecipe="true">
+      <RequiredSkill identifier="weapons" level="60" />
+      <RequiredItem identifier="magnesium" amount="4" />
+      <RequiredItem identifier="flashpowder" amount="2" />
+      <RequiredItem identifier="titanium" amount="8" />
+      <RequiredItem tag="berra_STANAG_ext" mincondition="0.0" maxcondition="0.0" usecondition="false" />
+    </Fabricate>
     <ItemContainer hideitems="true" capacity="1" drawinventory="false" canbeselected="false" ShowConditionInContainedStateIndicator="true" SpawnWithId="berra_50beowulf_ap" removecontaineditemsondeconstruct="true" containedstateindicatorstyle="bullet">
       <Containable items="berra_50beowulf_ap" />
       <StatusEffect type="OnUse" target="This" condition="-5" disabledeltatime="true">
@@ -1383,7 +1397,6 @@
     </Deconstruct>
     <Fabricate suitablefabricators="tsm_fabricator" requiredtime="35" displayname="m33" requiresrecipe="true">
       <RequiredSkill identifier="weapons" level="40" />
-      <RequiredItem identifier="tsm_triton_bag" amount="1" />
       <RequiredItem identifier="titanium" amount="6" />
       <RequiredItem identifier="magnesium" amount="6" />
       <RequiredItem identifier="flashpowder" amount="3"/>
@@ -1394,7 +1407,6 @@
       <RequiredItem identifier="magnesium" amount="6" />
       <RequiredItem identifier="flashpowder" amount="3" />
       <RequiredItem identifier="titanium" amount="6" />
-      <RequiredItem identifier="tsm_triton_bag" amount="1" />
       <RequiredItem tag="M107Mag" mincondition="0.0" maxcondition="0.0" usecondition="false" />
     </Fabricate>
     <ItemContainer hideitems="true" capacity="1" drawinventory="false" canbeselected="false" ShowConditionInContainedStateIndicator="true" SpawnWithId="berra_50bmg_m33" removecontaineditemsondeconstruct="true" containedstateindicatorstyle="bullet">
@@ -1444,13 +1456,13 @@
     <Sprite texture="%ModDir:3278494407%/Weapons/Other/M107Mag.png" depth="0.56" sourcerect="0,0,810,851" origin="0.5,0.5" />
     <Body width="100" height="200" density="50" />
     <Deconstruct time="18">
-      <Item identifier="tsm_triton_bag" amount="1" />
+      <Item identifier="tsm_triton_bag" outcondition="0.5" />
       <Item identifier="titanium" amount="3" />
       <Item identifier="steel" amount="1" />
     </Deconstruct>
     <Fabricate suitablefabricators="tsm_fabricator" requiredtime="35" displayname="m1022" requiresrecipe="true">
       <RequiredSkill identifier="weapons" level="40" />
-      <RequiredItem identifier="tsm_triton_bag" amount="1" />
+      <RequiredItem identifier="tsm_triton_bag" mincondition="0.5" usecondition="true"/>
       <RequiredItem identifier="titanium" amount="6" />
       <RequiredItem identifier="magnesium" amount="6" />
       <RequiredItem identifier="flashpowder" amount="3"/>
@@ -1461,7 +1473,7 @@
       <RequiredItem identifier="magnesium" amount="6" />
       <RequiredItem identifier="flashpowder" amount="3" />
       <RequiredItem identifier="titanium" amount="6" />
-      <RequiredItem identifier="tsm_triton_bag" amount="1" />
+      <RequiredItem identifier="tsm_triton_bag" mincondition="0.5" usecondition="true"/>
       <RequiredItem tag="M107Mag" mincondition="0.0" maxcondition="0.0" usecondition="false" />
     </Fabricate>
     <ItemContainer hideitems="true" capacity="1" drawinventory="false" canbeselected="false" ShowConditionInContainedStateIndicator="true" SpawnWithId="berra_50bmg_m1022" removecontaineditemsondeconstruct="true" containedstateindicatorstyle="bullet">
@@ -1536,39 +1548,31 @@
     <Upgrade gameversion="0.10.0.0" scale="0.5" />
   </Item>
 
-  <Item identifier="berra_STANAG_50beowulf_fr_drum" subcategory="Berra Group" category="weapon" maxstacksize="1" Health="35" maxstacksizecharacterinventory="3" cargocontaineridentifier="metalcrate" scale="0.255" tags="smallitem,berra_STANAG_ext,STANAG_50beowulf" impactsoundtag="impact_metal_light" hideinmenus="false">
+  <Item identifier="berra_STANAG_50beowulf_fr_drum" subcategory="Berra Group" category="weapon" maxstacksize="1" Health="35" maxstacksizecharacterinventory="3" cargocontaineridentifier="metalcrate" scale="0.255" tags="smallitem,berra_STANAG_drum,STANAG_50beowulf" impactsoundtag="impact_metal_light" hideinmenus="false">
     <InventoryIcon texture="%ModDir:2953749635%/weapons/木卫二联盟/coalition.png" sourcerect="2150,670,73,102" origin="0.5,0.5" />
     <Sprite texture="%ModDir:2953749635%/weapons/木卫二联盟/coalition.png" depth="0.56" sourcerect="2150,642,73,133" origin="0.5,0.5" />
     <Body width="30" height="58" density="50" />
-    <!--<Price baseprice="550" sold="false" minleveldifficulty="65" displaynonempty="true">
-      <Price storeidentifier="merchantoutpost" multiplier="1.4" />
-      <Price storeidentifier="merchantcity" multiplier="1.25" />
-      <Price storeidentifier="merchantresearch" multiplier="1.25" />
-      <Price storeidentifier="merchantmilitary" sold="true" multiplier="0.9" minavailable="0" maxavailable="4" />
-      <Price storeidentifier="merchantarmory" sold="true" multiplier="0.9" minavailable="0" maxavailable="4" />
-      <Price storeidentifier="merchantmine" multiplier="1.25" />
-    </Price>
     <Deconstruct time="18">
-      <Item identifier="plastic" outcondition="0.7" />
-      <Item identifier="flashpowder" mincondition="0.8" outcondition="0.6" />
-      <Item identifier="copper" mincondition="0.8" amount="1" />
+      <Item identifier="plastic" outcondition="1" />
+      <Item identifier="flashpowder" mincondition="0.8" amount="3" />
+      <Item identifier="copper" mincondition="0.8" amount="3" />
     </Deconstruct>
     <Fabricate suitablefabricators="fabricator" requiredtime="35" displayname="50beowulf_fr" requiresrecipe="true">
-      <RequiredSkill identifier="weapons" level="40" />
+      <RequiredSkill identifier="weapons" level="80" />
       <RequiredItem identifier="magnesium" amount="4" />
-      <RequiredItem identifier="flashpowder" amount="2" />
+      <RequiredItem identifier="flashpowder" amount="6" />
       <RequiredItem identifier="plastic" />
-      <RequiredItem identifier="copper" amount="6" />
-      <RequiredItem identifier="steel" amount="4" />
+      <RequiredItem identifier="copper" amount="8" />
+      <RequiredItem identifier="steel" amount="6" />
     </Fabricate>
     <Fabricate suitablefabricators="fabricator" requiredtime="35" displayname="50beowulf_fr_recycle" requiresrecipe="true">
-      <RequiredSkill identifier="weapons" level="40" />
+      <RequiredSkill identifier="weapons" level="80" />
       <RequiredItem identifier="magnesium" amount="4" />
-      <RequiredItem identifier="flashpowder" amount="2" />
-      <RequiredItem identifier="copper" amount="6" />
-      <RequiredItem identifier="steel" amount="4" />
-      <RequiredItem tag="berra_STANAG_ext" mincondition="0.0" maxcondition="0.0" usecondition="false" />
-    </Fabricate>-->
+      <RequiredItem identifier="flashpowder" amount="6" />
+      <RequiredItem identifier="copper" amount="8" />
+      <RequiredItem identifier="steel" amount="6" />
+      <RequiredItem tag="berra_STANAG_drum" mincondition="0.0" maxcondition="0.0" usecondition="false" />
+    </Fabricate>
     <ItemContainer hideitems="true" capacity="1" drawinventory="false" canbeselected="false" ShowConditionInContainedStateIndicator="true" SpawnWithId="berra_50beowulf_fr" removecontaineditemsondeconstruct="true" containedstateindicatorstyle="bullet">
       <Containable items="berra_50beowulf_fr" />
       <StatusEffect type="OnUse" target="This" condition="-1" disabledeltatime="true">
@@ -1578,22 +1582,14 @@
     <Holdable canBeCombined="true" slots="Any,RightHand,LeftHand" handle1="0,0" msg="ItemMsgPickUpSelect" />
     <Upgrade gameversion="0.10.0.0" scale="0.5" />
   </Item>
-  <Item identifier="berra_STANAG_50beowulf_ap_drum" subcategory="Berra Group" category="weapon" maxstacksize="1" Health="35" maxstacksizecharacterinventory="3" cargocontaineridentifier="metalcrate" scale="0.255" tags="smallitem,berra_STANAG_ext,STANAG_50beowulf" impactsoundtag="impact_metal_light" hideinmenus="false">
+  <Item identifier="berra_STANAG_50beowulf_ap_drum" subcategory="Berra Group" category="weapon" maxstacksize="1" Health="35" maxstacksizecharacterinventory="3" cargocontaineridentifier="metalcrate" scale="0.255" tags="smallitem,berra_STANAG_drum,STANAG_50beowulf" impactsoundtag="impact_metal_light" hideinmenus="false">
     <InventoryIcon texture="%ModDir:2953749635%/weapons/木卫二联盟/coalition.png" sourcerect="2150,670,73,102" origin="0.5,0.5" />
     <Sprite texture="%ModDir:2953749635%/weapons/木卫二联盟/coalition.png" depth="0.56" sourcerect="2150,642,73,133" origin="0.5,0.5" />
     <Body width="30" height="58" density="50" />
-    <!--<Price baseprice="600" sold="false" minleveldifficulty="65" displaynonempty="true">
-      <Price storeidentifier="merchantoutpost" multiplier="1.4" />
-      <Price storeidentifier="merchantcity" multiplier="1.25" />
-      <Price storeidentifier="merchantresearch" multiplier="1.25" />
-      <Price storeidentifier="merchantmilitary" sold="true" multiplier="0.9" minavailable="0" maxavailable="4" />
-      <Price storeidentifier="merchantarmory" sold="true" multiplier="0.9" minavailable="0" maxavailable="4" />
-      <Price storeidentifier="merchantmine" multiplier="1.25" />
-    </Price>-->
     <Deconstruct time="18">
-      <Item identifier="plastic" outcondition="0.7" />
-      <Item identifier="flashpowder" mincondition="0.8" outcondition="0.6" />
-      <Item identifier="titanium" mincondition="0.8" amount="1" />
+      <Item identifier="plastic" outcondition="1" />
+      <Item identifier="flashpowder" mincondition="0.8" amount="3" />
+      <Item identifier="titanium" mincondition="0.8" amount="6" />
     </Deconstruct>
     <ItemContainer hideitems="true" capacity="1" drawinventory="false" canbeselected="false" ShowConditionInContainedStateIndicator="true" SpawnWithId="berra_50beowulf_ap" removecontaineditemsondeconstruct="true" containedstateindicatorstyle="bullet">
       <Containable items="berra_50beowulf_ap" />

--- a/Weapons/Magazine/Magazines.xml
+++ b/Weapons/Magazine/Magazines.xml
@@ -1416,8 +1416,8 @@
     </Deconstruct>
     <Fabricate suitablefabricators="tsm_fabricator" requiredtime="35" displayname="m903" requiresrecipe="true">
       <RequiredSkill identifier="weapons" level="40" />
-      <RequiredItem identifier="tsm_triton_bag" amount="4" />
-      <RequiredItem identifier="tsm_hengberley_star" amount="2" />
+      <RequiredItem identifier="tsm_triton_bag" amount="3" />
+      <RequiredItem identifier="tsm_hengberley_star" amount="1" />
       <RequiredItem identifier="magnesium" amount="6" />
       <RequiredItem identifier="flashpowder" amount="4"/>
     <RequiredItem identifier="steel" amount="2"/>
@@ -1426,8 +1426,8 @@
       <RequiredSkill identifier="weapons" level="40" />
       <RequiredItem identifier="magnesium" amount="6" />
       <RequiredItem identifier="flashpowder" amount="4" />
-      <RequiredItem identifier="tsm_hengberley_star" amount="2" />
-      <RequiredItem identifier="tsm_triton_bag" amount="4" />
+      <RequiredItem identifier="tsm_hengberley_star" amount="1" />
+      <RequiredItem identifier="tsm_triton_bag" amount="3" />
       <RequiredItem tag="M107Mag" mincondition="0.0" maxcondition="0.0" usecondition="false" />
     </Fabricate>
     <ItemContainer hideitems="true" capacity="1" drawinventory="false" canbeselected="false" ShowConditionInContainedStateIndicator="true" SpawnWithId="berra_50bmg_m903" removecontaineditemsondeconstruct="true" containedstateindicatorstyle="bullet">
@@ -1461,7 +1461,7 @@
       <RequiredItem identifier="magnesium" amount="6" />
       <RequiredItem identifier="flashpowder" amount="3" />
       <RequiredItem identifier="titanium" amount="6" />
-      <RequiredItem identifier="tsm_triton_bag" amount="2" />
+      <RequiredItem identifier="tsm_triton_bag" amount="1" />
       <RequiredItem tag="M107Mag" mincondition="0.0" maxcondition="0.0" usecondition="false" />
     </Fabricate>
     <ItemContainer hideitems="true" capacity="1" drawinventory="false" canbeselected="false" ShowConditionInContainedStateIndicator="true" SpawnWithId="berra_50bmg_m1022" removecontaineditemsondeconstruct="true" containedstateindicatorstyle="bullet">
@@ -2488,26 +2488,21 @@
     <Body width="40" height="14" density="30" />
     <Pickable slots="Any" msg="ItemMsgPickUpSelect" />
     <Projectile characterusable="false" Hitscan="true" spread="0.02" DamageDoors="true" >
-      <Attack structuredamage="80" targetforce="12" itemdamage="80" penetration="0.8" severlimbsprobability="0.8">
-        <Affliction identifier="gunshotwound" strength="50" />
-        <Affliction identifier="lacerations" strength="50" />
-        <Affliction identifier="bleeding" strength="20" />
-        <Affliction identifier="stun" strength="0.8" />
-        <Affliction identifier="burn" strength="20" />
+      <Attack structuredamage="80" targetforce="12" itemdamage="80" penetration="0.9" severlimbsprobability="0.8">
+        <Affliction identifier="gunshotwound" strength="60" />
+        <Affliction identifier="lacerations" strength="60" />
+        <Affliction identifier="bleeding" strength="30" />
+        <Affliction identifier="stun" strength="1" />
+        <Affliction identifier="burn" strength="30" />
       </Attack>
-      <StatusEffect type="OnImpact" target="UseTarget" OneShot="true">
-        <Explosion range="80.0" structuredamage="120" itemdamage="120" force="5" severlimbsprobability="1" debris="false" decal="explosion" decalsize="0.75" penetration="0.8" >
-          <Affliction identifier="explosiondamage" strength="80" />
-          <Affliction identifier="lacerations" strength="60" />
+      <StatusEffect type="OnImpact" target="UseTarget" OneShot="true" multiplyAfflictionsByMaxVitality="true">
+        <Explosion range="80.0" structuredamage="120" itemdamage="120" force="5" severlimbsprobability="5" debris="false" decal="explosion" decalsize="0.75" penetration="0.9" >
+          <Affliction identifier="explosiondamage" strength="90" />
+          <Affliction identifier="lacerations" strength="70" />
           <Affliction identifier="burn" strength="50" />
           <Affliction identifier="bleeding" strength="40" />
           <Affliction identifier="stun" strength="3" />
         </Explosion>
-      </StatusEffect>
-      <StatusEffect type="OnImpact" target="UseTarget">
-        <Conditional entitytype="eq Structure" />
-        <Conditional hastag="eq door" />
-        <ParticleEmitter particle="spark" copyentityangle="true" anglemin="-10" anglemax="10" particleamount="5" velocitymin="-10" velocitymax="-200" scalemin="0.5" scalemax="1" />
       </StatusEffect>
       <StatusEffect type="OnNotContained" target="This" stackable="false">
         <Remove />
@@ -2522,11 +2517,11 @@
     <Pickable slots="Any" msg="ItemMsgPickUpSelect" />
     <Projectile characterusable="false" Hitscan="true" MaxTargetsToHit="3" spread="0.01" DamageDoors="true" >
       <Attack structuredamage="10" targetforce="15" itemdamage="10" penetration="1" severlimbsprobability="0.2">
-        <Affliction identifier="gunshotwound" strength="80" />
-        <Affliction identifier="lacerations" strength="80" />
-        <Affliction identifier="bleeding" strength="60" />
-        <Affliction identifier="stun" strength="0.8" />
-        <Affliction identifier="triton_7L" strength="25" />
+        <Affliction identifier="gunshotwound" strength="90" />
+        <Affliction identifier="lacerations" strength="90" />
+        <Affliction identifier="bleeding" strength="70" />
+        <Affliction identifier="stun" strength="1" />
+        <Affliction identifier="triton_7L" strength="40" />
       </Attack>
       <StatusEffect type="OnImpact" target="UseTarget">
         <Conditional entitytype="eq Structure" />

--- a/filelist.xml
+++ b/filelist.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<contentpackage name="九州武库·CBRN拓展" modversion="4.3.4" corepackage="False" steamworkshopid="3278494407" gameversion="1.7.7.0">
+<contentpackage name="九州武库·CBRN拓展" modversion="4.3.5" corepackage="False" steamworkshopid="3278494407" gameversion="1.7.7.0">
   <Item file="%ModDir%/gear.xml" />
   <Item file="%ModDir%/material.xml" />
   <Item file="%ModDir%/shell.xml" />

--- a/gear.xml
+++ b/gear.xml
@@ -439,19 +439,10 @@
       <StatusEffect type="OnWearing" target="Character" HideFace="true" setvalue="true" disabledeltatime="true" />
       <sprite name="CBRN3A Mask" texture="%ModDir:3278494407%/Jobgear/Under_Masks/APR-2.png" canbehiddenbyotherwearables="false" alphaclipotherwearables="false" sourcerect="304,212,128,153" depth="0.55" limb="Head" depthlimb="Head" rotation="0" scale="0.15" origin="0.15,0.3" />
       <damagemodifier armorsector="0,360" afflictionidentifiers="gunshotwound" damagemultiplier="0.8" deflectprojectiles="true" />
-      <StatusEffect type="OnWearing" targettype="Contained" targets="berra_filiter" Condition="-0.2" >
+      <StatusEffect type="OnWearing" target="Contained" targets="maskfilter" Condition="-0.5" >
         <Conditional IsDead="False"/>
       </StatusEffect>
-      <StatusEffect type="OnWearing" targettype="Contained" targets="tsm_filiter" Condition="-0.5" >
-        <Conditional IsDead="False"/>
-      </StatusEffect>
-      <StatusEffect type="OnWearing" targettype="Contained" targets="col_filiter" Condition="-0.8" >
-        <Conditional IsDead="False"/>
-      </StatusEffect>
-      <StatusEffect type="OnWearing" targettype="Contained" targets="sep_filiter" Condition="-0.8" >
-        <Conditional IsDead="False"/>
-      </StatusEffect>
-      <StatusEffect type="OnWearing" targettype="Contained" targets="oxygensource" Condition="-1.0" >
+      <StatusEffect type="OnWearing" target="Contained" targets="oxygensource" Condition="-1.0" >
         <Conditional IsDead="False"/>
       </StatusEffect>
       <StatusEffect type="OnWearing" target="Character" disabledeltatime="true" ObstructVisionAmount="0.3" setvalue="true" comparison="And">
@@ -460,11 +451,11 @@
         <Sound file="%ModDir:3278494407%/Jobgear/Under_Masks/maskedbreath.ogg" volume="0.3" loop="true" />
       </StatusEffect>
       <StatusEffect type="OnWearing" target="Character" disabledeltatime="true" setvalue="true">
-        <Affliction identifier="APR" amount="10" />
+        <Affliction identifier="APR_M" amount="10" />
         <RequiredItems items="maskfilter" type="Contained" />
       </StatusEffect>
       <StatusEffect type="OnWearing" target="Character" OxygenAvailable="1000" disabledeltatime="true" setvalue="true">
-        <Affliction identifier="APR" amount="10" />
+        <Affliction identifier="APR_M" amount="10" />
         <RequiredItems items="oxygensource" type="Contained" />
       </StatusEffect>
       <ItemContainer capacity="1" maxstacksize="1" containedstateindicatorslot="0" containedstateindicatorstyle="tank">
@@ -1207,7 +1198,7 @@
     <Wearable slots="Bag" msg="ItemMsgEquipSelect" canbeselected="false" canbepicked="true" pickkey="Select">
       <sprite name="M82 Worn" texture="%ModDir:3278494407%/Weapons/Other/M82A1_29.png" canbehiddenbyotherwearables="false" sourcerect="0,0,1920,476" depth="0.55" limb="Torso" depthlimb="LeftArm" rotation="90" scale="0.1" origin="0.5,0.7" />
     </Wearable>
-    <RangedWeapon reload="0.75" weapondamagemodifier="1.6" penetration="0.9" holdtrigger="false" barrelpos="900,95" spread="0" unskilledspread="40" combatPriority="100" drawhudwhenequipped="true" crosshairscale="0.2">
+    <RangedWeapon reload="0.75" weapondamagemodifier="1.8" penetration="0.9" holdtrigger="false" barrelpos="900,95" spread="0" unskilledspread="40" combatPriority="100" drawhudwhenequipped="true" crosshairscale="0.2">
       <RequiredSkill identifier="weapons" level="80" />
       <Crosshair texture="Content/Items/Weapons/Crosshairs.png" sourcerect="0,256,256,256" />
       <CrosshairPointer texture="Content/Items/Weapons/Crosshairs.png" sourcerect="256,256,256,256" />
@@ -1272,7 +1263,7 @@
     <Wearable slots="Bag" msg="ItemMsgEquipSelect" canbeselected="false" canbepicked="true" pickkey="Select">
       <sprite name="M107 Worn" texture="%ModDir:3278494407%/Weapons/Other/M107A1_20.png" canbehiddenbyotherwearables="false" sourcerect="0,0,1646,302" depth="0.55" limb="Torso" depthlimb="LeftArm" rotation="90" scale="0.1" origin="0.5,0.7" />
     </Wearable>
-    <RangedWeapon reload="0.75" weapondamagemodifier="1.4" penetration="0.75" holdtrigger="false" barrelpos="680,30" spread="0.01" unskilledspread="30" combatPriority="100" drawhudwhenequipped="true" crosshairscale="0.1">
+    <RangedWeapon reload="0.75" weapondamagemodifier="1.6" penetration="0.75" holdtrigger="false" barrelpos="680,30" spread="0.01" unskilledspread="30" combatPriority="100" drawhudwhenequipped="true" crosshairscale="0.1">
       <RequiredSkill identifier="weapons" level="80" />
       <Crosshair texture="Content/Items/Weapons/Crosshairs.png" sourcerect="0,256,256,256" />
       <CrosshairPointer texture="Content/Items/Weapons/Crosshairs.png" sourcerect="256,256,256,256" />
@@ -1337,7 +1328,7 @@
     <Wearable slots="Bag" msg="ItemMsgEquipSelect" canbeselected="false" canbepicked="true" pickkey="Select">
       <sprite name="M107Auto Worn" texture="%ModDir:3278494407%/Weapons/Other/M107A1_20_FA.png" canbehiddenbyotherwearables="false" sourcerect="0,0,1646,302" depth="0.55" limb="Torso" depthlimb="LeftArm" rotation="90" scale="0.1" origin="0.5,0.7" />
     </Wearable>
-    <RangedWeapon reload="0.2" weapondamagemodifier="1.0" penetration="0.5" holdtrigger="true" barrelpos="680,30" spread="1" unskilledspread="60" combatPriority="120" drawhudwhenequipped="true" crosshairscale="0.2">
+    <RangedWeapon reload="0.2" weapondamagemodifier="1.5" penetration="0.5" holdtrigger="true" barrelpos="680,30" spread="1" unskilledspread="60" combatPriority="120" drawhudwhenequipped="true" crosshairscale="0.2">
       <RequiredSkill identifier="weapons" level="100" />
       <Crosshair texture="Content/Items/Weapons/Crosshairs.png" sourcerect="0,256,256,256" />
       <CrosshairPointer texture="Content/Items/Weapons/Crosshairs.png" sourcerect="256,256,256,256" />
@@ -1489,7 +1480,7 @@
     </Holdable>
     <aitarget sightrange="2500" soundrange="3000" fadeouttime="6" />
   </Item>
-  <Item identifier="tsm_filiter" subcategory="TSM" category="Equipment" maxstacksize="8" maxstacksizecharacterinventory="2" scale="0.11" cargocontaineridentifier="metalcrate" tags="smallitem,maskfilter" impactsoundtag="impact_metal_light">
+  <Item identifier="tsm_filiter" Health="100" subcategory="TSM" category="Equipment" maxstacksize="8" maxstacksizecharacterinventory="2" scale="0.11" cargocontaineridentifier="metalcrate" tags="smallitem,maskfilter" impactsoundtag="impact_metal_light">
     <InventoryIcon texture="%ModDir:3278494407%/Jobgear/T.S.M/filter.png" sourcerect="0,0,117,109" origin="0.5,0.5" />
     <Sprite texture="%ModDir:3278494407%/Jobgear/T.S.M/filter.png" depth="0.56" sourcerect="0,0,117,109" origin="0.5,0.5" />
     <Body width="72" height="90" density="25" />
@@ -1519,7 +1510,7 @@
     </Fabricate>
     <Pickable slots="Any" msg="ItemMsgPickUpSelect" />
   </Item>
-  <Item identifier="berra_filiter" subcategory="Berra Group" category="Equipment" maxstacksize="8" maxstacksizecharacterinventory="2" scale="0.11" cargocontaineridentifier="metalcrate" tags="smallitem,maskfilter" impactsoundtag="impact_metal_light">
+  <Item identifier="berra_filiter" Health="150" subcategory="Berra Group" category="Equipment" maxstacksize="8" maxstacksizecharacterinventory="2" scale="0.11" cargocontaineridentifier="metalcrate" tags="smallitem,maskfilter" impactsoundtag="impact_metal_light">
     <InventoryIcon texture="%ModDir:3278494407%/Jobgear/T.S.M/filter.png" sourcerect="0,0,117,109" origin="0.5,0.5" />
     <Sprite texture="%ModDir:3278494407%/Jobgear/T.S.M/filter.png" depth="0.56" sourcerect="0,0,117,109" origin="0.5,0.5" />
     <Body width="72" height="90" density="25" />
@@ -1549,7 +1540,7 @@
     </Fabricate>
     <Pickable slots="Any" msg="ItemMsgPickUpSelect" />
   </Item>
-  <Item identifier="col_filiter" subcategory="Berra Group" category="Equipment" maxstacksize="8" maxstacksizecharacterinventory="2" scale="0.11" cargocontaineridentifier="metalcrate" tags="smallitem,maskfilter" impactsoundtag="impact_metal_light">
+  <Item identifier="col_filiter" Health="80" subcategory="Berra Group" category="Equipment" maxstacksize="8" maxstacksizecharacterinventory="2" scale="0.11" cargocontaineridentifier="metalcrate" tags="smallitem,maskfilter" impactsoundtag="impact_metal_light">
     <InventoryIcon texture="%ModDir:3278494407%/Jobgear/T.S.M/filter.png" sourcerect="0,0,117,109" origin="0.5,0.5" />
     <Sprite texture="%ModDir:3278494407%/Jobgear/T.S.M/filter.png" depth="0.56" sourcerect="0,0,117,109" origin="0.5,0.5" />
     <Body width="72" height="90" density="25" />
@@ -1579,7 +1570,7 @@
     </Fabricate>
     <Pickable slots="Any" msg="ItemMsgPickUpSelect" />
   </Item>
-  <Item identifier="sep_filiter" subcategory="Berra Group" category="Equipment" maxstacksize="8" maxstacksizecharacterinventory="2" scale="0.11" cargocontaineridentifier="metalcrate" tags="smallitem,maskfilter" impactsoundtag="impact_metal_light">
+  <Item identifier="sep_filiter" Health="80" subcategory="Berra Group" category="Equipment" maxstacksize="8" maxstacksizecharacterinventory="2" scale="0.11" cargocontaineridentifier="metalcrate" tags="smallitem,maskfilter" impactsoundtag="impact_metal_light">
     <InventoryIcon texture="%ModDir:3278494407%/Jobgear/T.S.M/filter.png" sourcerect="0,0,117,109" origin="0.5,0.5" />
     <Sprite texture="%ModDir:3278494407%/Jobgear/T.S.M/filter.png" depth="0.56" sourcerect="0,0,117,109" origin="0.5,0.5" />
     <Body width="72" height="90" density="25" />
@@ -1936,9 +1927,9 @@
     <InventoryIcon texture="%ModDir:2953749635%/weapons/其他/近战.png" sourcerect="779,896,93,93" origin="0.5,0.5" /><!--TODO: New Spirites-->
     <Sprite texture="%ModDir:2953749635%/weapons/其他/近战.png" sourcerect="0,262,722,178" depth="0.55" origin="0.5,0.5" />
     <Body width="700" height="150" density="45" />
-    <MeleeWeapon slots="RightHand+LeftHand,Any" controlpose="true" holdpos="16,-50" aimpos="50,0" handle1="-20,-3" handle2="15,3" holdangle="35" reload="0.8" range="100" combatPriority="50" msg="ItemMsgPickUpSelect">
+    <MeleeWeapon slots="RightHand+LeftHand,Any" controlpose="true" holdpos="16,-50" aimpos="50,0" handle1="-20,-3" handle2="15,3" holdangle="35" reload="1" range="100" combatPriority="50" msg="ItemMsgPickUpSelect">
       <Attack targetimpulse="4" severlimbsprobability="0.3" ballastfloradamage="80" structuredamage="0" itemdamage="3000" penetration="0.8">
-        <Affliction identifier="blunttrauma" strength="60" />
+        <Affliction identifier="blunttrauma" strength="40" />
         <Affliction identifier="internaldamage" strength="40" />
         <Affliction identifier="stun" strength="1.5" />
         <Sound file="Content/Items/Weapons/Smack1.ogg" selectionmode="random" range="500"/>
@@ -2011,6 +2002,14 @@
         <LuaHook name="Drone.control" />
       </StatusEffect>
     </MeleeWeapon>
+    <Deconstruct time="15">
+      <Item identifier="wificomponent"/>
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="20" requiresrecipe="false">
+      <RequiredSkill identifier="weapons" level="50" />
+      <RequiredItem identifier="wificomponent" amount="1"/>
+      <RequiredItem tag="wire" amount="1"/>
+    </Fabricate>
     <!--<CustomInterface canbeselected="true" drawhudwhenequipped="true">
       <GuiFrame relativesize="0.5,0.5" anchor="CenterLeft" pivot="CenterLeft" style="ItemUI" />
     </CustomInterface>-->
@@ -2069,6 +2068,63 @@
         <StatusEffect type="OnContaining" targettype="This" Voltage="1.0" setvalue="true" />
       </Containable>
     </ItemContainer>
+    <AiTarget soundrange="1200" sonarlabel="sig.sos" sight="1200" staticsight="true"/>
+  </Item>
+  <Item identifier="uhm_headset_autoinjector" scale="0.5" category="Equipment,Medical" tags="smallitem,mobileradio" allowasextracargo="true" description="" cargocontaineridentifier="metalcrate" impactsoundtag="impact_metal_light">
+    <PreferredContainer primary="medcab"/>
+    <Price baseprice="200" sold="false">
+      <Price storeidentifier="merchantoutpost" />
+      <Price storeidentifier="merchantcity" multiplier="0.9" />
+      <Price storeidentifier="merchantresearch" />
+      <Price storeidentifier="merchantmilitary" />
+      <Price storeidentifier="merchantmine" />
+    </Price>
+    <InventoryIcon texture="Content/Items/JobGear/TalentGear.png" sourcerect="113,264,58,45" origin="0.5,0.5" />
+    <Sprite name="Headset" texture="Content/Items/JobGear/TalentGear.png" depth="0.6" sourcerect="255,305,72,60" origin="0.35,0.5" />
+    <Body radius="20" height="20" density="15" />
+    <Deconstruct time="10">
+      <Item identifier="plastic" amount="2" />
+      <Item identifier="copper" />
+      <Item identifier="sonarbeacon" />
+      <Item identifier="fpgacircuit" />
+    </Deconstruct>
+    <Fabricate suitablefabricators="fabricator" requiredtime="10" requiresrecipe="true">
+      <RequiredSkill identifier="mechanical" level="30" />
+      <RequiredItem identifier="autoinjectorheadset" />
+      <RequiredItem identifier="fpgacircuit" />
+      <RequiredItem identifier="sonarbeacon" />
+    </Fabricate>
+    <LightComponent LightColor="0,0,0,0" range="0" powerconsumption="0" blinkfrequency="2" IsOn="false" canbeselected="false">
+      <StatusEffect type="OnActive" targettype="Contained" Condition="-0.05">
+        <RequiredItem items="mobilebattery" type="Contained" />
+      </StatusEffect>
+      <StatusEffect type="OnActive" targettype="This" SoundRange="50000" setvalue="true">
+        <Conditional Voltage="gt 0.5" targetitemcomponent="LightComponent" />
+        <sound file="Content/Items/WarningBeepSlow.ogg" range="1000.0" loop="true" volume="1.0" />
+      </StatusEffect>
+    </LightComponent>
+    <WifiComponent range="35000.0" LinkToChat="true" MinChatMessageInterval="0.0" />
+    <ItemContainer capacity="1" maxstacksize="1" autoinject="true">
+      <SlotIcon slotindex="0" texture="Content/UI/StatusMonitorUI.png" sourcerect="384,448,64,64" origin="0.5,0.5" />
+      <SlotIcon slotindex="1" texture="Content/UI/StatusMonitorUI.png" sourcerect="128,448,64,64" origin="0.5,0.5" />
+      <Containable items="chem,syringe" />
+      <SubContainer capacity="1" maxstacksize="1">
+        <Containable items="mobilebattery">
+          <StatusEffect type="OnContaining" targettype="This" targetslot="1" Voltage="1.0" setvalue="true" />
+        </Containable>
+      </SubContainer>
+    </ItemContainer>
+    <Wearable limbtype="Head" slots="Any,Headset" msg="ItemMsgPickUpSelect" displaycontainedstatus="true">
+      <sprite name="Headset Wearable" texture="Content/Items/JobGear/TalentGear.png" sourcerect="255,305,72,58" limb="Head" hidelimb="false" inheritlimbdepth="true" inheritscale="true" ignorelimbscale="true" scale="0.7" hideotherwearables="false" origin="0.5,0.5" >
+        <LightComponent LightColor="255,0,0,130" range="59" powerconsumption="10" blinkfrequency="2" IsOn="false" canbeselected="false" AllowInGameEditing="false"/>
+      </sprite>
+      <StatusEffect type="OnWearing" target="This" disabledeltatime="true" checkconditionalalways="true" IsOn="true" setvalue="true">
+        <Conditional IsUnconscious="eq true" TargetContainer="true" TargetGrandParent="true" />
+      </StatusEffect>
+      <StatusEffect type="OnWearing" target="This" disabledeltatime="true" checkconditionalalways="true" IsOn="false" setvalue="true">
+        <Conditional IsUnconscious="eq false" TargetContainer="true" TargetGrandParent="true" />
+      </StatusEffect>
+    </Wearable>
     <AiTarget soundrange="1200" sonarlabel="sig.sos" sight="1200" staticsight="true"/>
   </Item>
 

--- a/localization/English.xml
+++ b/localization/English.xml
@@ -68,12 +68,8 @@
   <entitydescription.tes20mag_arr>20mm Flechette used by "Punisher", EXTREMELY effective in close range</entitydescription.tes20mag_arr>
   <entitydescription.tes20mag_he>20mm programable high-explosive used by "Punisher" \nLet's blow something up \nWARNING:CURRENTLY NOT PROGRAMABLE</entitydescription.tes20mag_he>
   <entitydescription.tes20mag_ll>20mm Rubber Less Lethal shot used by "Punisher",IT HURTS...</entitydescription.tes20mag_ll>
-  <entitydescription.berra_STANAG_50beowulf_fr>STANAG Magazine \nContaining 7 12.7×45 Fragile rounds \nPoor penetration but extreme stopping power</entitydescription.berra_STANAG_50beowulf_fr>
-  <entitydescription.berra_STANAG_50beowulf_ap>STANAG Magazine \nContaining 7 12.7×45 AP rounds \nPerfect penetration and (relatively)high stopping power </entitydescription.berra_STANAG_50beowulf_ap>
   <entitydescription.berra_STANAG_458socom>STANAG Magazine \nContaining 10 .458 SOCOM rounds \nGood stopping power and penetration,less expensive than 12.7×45</entitydescription.berra_STANAG_458socom>
   <entitydescription.berra_STANAG_458socom_ext>STANAG Magazine \nContaining 20 .458 SOCOM rounds \nGood stopping power and penetration,less expensive than 12.7×45</entitydescription.berra_STANAG_458socom_ext>
-  <entitydescription.berra_STANAG_50beowulf_fr_ext>STANAG Magazine \nContaining 15 12.7×45 Fragile rounds \nPoor penetration but extreme stopping power</entitydescription.berra_STANAG_50beowulf_fr_ext>
-  <entitydescription.berra_STANAG_50beowulf_ap_ext>STANAG Magazine \nContaining 15 12.7×45 AP rounds \nPerfect penetration and (relatively)high stopping power! \nLet's kick some ass</entitydescription.berra_STANAG_50beowulf_ap_ext>
   <entitydescription.berra_50bmg_belt_fmjt>.50BMG belt \nM33 FMJ \n500 rounds MAX \nSTOP WORRING ABOUT AMMUNITION,JUST SHOOT!!!!</entitydescription.berra_50bmg_belt_fmjt>
   <entitydescription.berra_mk153_dumb>Mk153 SMAW Training rounds,the same trajectory with standard MK153 rounds \nSERIOUSLY,DO NOT FIGHT YOUR ENEMY WITH THIS \nBackblast range:4.4m</entitydescription.berra_mk153_dumb>
   <entitydescription.berra_mk153_inc>Mk153 SMAW Incendiary rounds,much more heavier=much more fuel \nBARBECUE TIME \nBackblast range:4.4m</entitydescription.berra_mk153_inc>
@@ -380,7 +376,6 @@
   
   <talentdescription.rangedspreadreduction>Your spread of Rangedweapons will reduce[amount]%</talentdescription.rangedspreadreduction>
   <talentdescription.aimbetter>Your spread of Rangedweapons will reduce [amount]% when aiming</talentdescription.aimbetter>
-  <talentdescription.dutyofcbrn>When you are attacked, acquire [affliction2] \nYou will not fall unconscious for [time] seconds when health below 0</talentdescription.dutyofcbrn>
   <talentdescription.nanomachine>Plant nanomachine in your body,providing [amount]% resist fro poison</talentdescription.nanomachine>
   <talentdescription.nanomachineondamaged>When your health below [amount]%, heal yourself using nanomachine  \nNanomachine will last [time] seconds after reaching [amount]% health</talentdescription.nanomachineondamaged>
   
@@ -584,4 +579,16 @@
   <entityname.uhm_headset>User Health Monitoring Headset</entityname.uhm_headset>
   <entitydescription.uhm_headset>A headset with built-in User Health Monitor, can transmit SOS signal when user is unconscious \nRequires Mobilebattery to work</entitydescription.uhm_headset>
   <sig.sos>User Status Critical \nS.O.S</sig.sos>
+
+  <entityname.uhm_headset_autoinjector>User Health Monitoring Auto-Injector Headset</entityname.uhm_headset_autoinjector>
+  <entitydescription.uhm_headset_autoinjector>A headset with built-in User Health Monitoring Auto-Injector Headset, can send SOS signal when user is critical \nRequires battery</entitydescription.uhm_headset_autoinjector>
+  <talentdescription.dutyofcbrn>When you were attacked, acquire [affliction1], cooldown for [cd1] and [affliction2], cooldown for [cd2] \nYou will not fall unconscious for [time] seconds when health below 0 \n You will not die to afflictions when you are conscious</talentdescription.dutyofcbrn>
+  <talentvalue.berra_STANAG_50beowulf_fr_drum>PMAG-D60 Drum .50Beowulf Fragile</talentvalue.berra_STANAG_50beowulf_fr_drum>
+  <talentvalue.berra_STANAG_50beowulf_ap_ext>STANAG Magazine(Extened) .50Beowulf AP</talentvalue.berra_STANAG_50beowulf_ap_ext>
+  <talentvalue.berra_M107Mag_m903>M82/M107 Magazine M903 SLAP</talentvalue.berra_M107Mag_m903>
+  <talentvalue.berra_M107Mag_mk211mod0>M82/M107 Magazine Mk211 Mod.0 APHEI</talentvalue.berra_M107Mag_mk211mod0>
+  <entitydescription.berra_STANAG_50beowulf_fr_ext>STANAG Magazine \nContaining 20 12.7×45 Fragile rounds \nPoor penetration but extreme stopping power</entitydescription.berra_STANAG_50beowulf_fr_ext>
+  <entitydescription.berra_STANAG_50beowulf_ap_ext>STANAG Magazine \nContaining 20 12.7×45 AP rounds \nPerfect penetration and (relatively)high stopping power! \nLet's kick some ass</entitydescription.berra_STANAG_50beowulf_ap_ext>
+  <entitydescription.berra_STANAG_50beowulf_fr>STANAG Magazine \nContaining 10 12.7×45 Fragile rounds \nPoor penetration but extreme stopping power</entitydescription.berra_STANAG_50beowulf_fr>
+  <entitydescription.berra_STANAG_50beowulf_ap>STANAG Magazine \nContaining 10 12.7×45 AP rounds \nPerfect penetration and (relatively)high stopping power </entitydescription.berra_STANAG_50beowulf_ap>
 </infotexts>

--- a/localization/SimplifiedChinese.xml
+++ b/localization/SimplifiedChinese.xml
@@ -73,12 +73,8 @@
   <entitydescription.tes20mag_arr>惩罚者使用的20mm箭霰弹,高穿,多弹头,是CQB的最佳选择</entitydescription.tes20mag_arr>
   <entitydescription.tes20mag_he>惩罚者使用的20mm可编程榴弹(当然,编程还没搞出来) \n该开炸了,先生们</entitydescription.tes20mag_he>
   <entitydescription.tes20mag_ll>惩罚者使用的20mm硬质橡胶低致命弹药,当然,还是挺疼的...</entitydescription.tes20mag_ll>
-  <entitydescription.berra_STANAG_50beowulf_fr>STANAG弹匣 \n内装7发.50贝奥武夫易碎弹 \n穿甲性能不佳,然而强大的停止力弥补了这一点</entitydescription.berra_STANAG_50beowulf_fr>
-  <entitydescription.berra_STANAG_50beowulf_ap>STANAG弹匣 \n内装7发.50贝奥武夫穿甲弹 \n高穿透力,高停止力 </entitydescription.berra_STANAG_50beowulf_ap>
   <entitydescription.berra_STANAG_458socom>STANAG弹匣 \n内装10发.458 SOCOM弹 \n穿甲性能和停止力都不错,造价也没有.50那么极端</entitydescription.berra_STANAG_458socom>
   <entitydescription.berra_STANAG_458socom_ext>STANAG弹匣 \n内装20发.458 SOCOM弹 \n穿甲性能和停止力都不错,造价也没有.50那么极端</entitydescription.berra_STANAG_458socom_ext>
-  <entitydescription.berra_STANAG_50beowulf_fr_ext>STANAG弹匣 \n内装15发.50贝奥武夫易碎弹 \n穿甲性能不佳,然而强大的停止力弥补了这一点</entitydescription.berra_STANAG_50beowulf_fr_ext>
-  <entitydescription.berra_STANAG_50beowulf_ap_ext>STANAG弹匣 \n内装15发.50贝奥武夫穿甲弹 \n高穿透力,高停止力,开创!</entitydescription.berra_STANAG_50beowulf_ap_ext>
   <entitydescription.berra_50bmg_belt_fmjt>M2HB重机枪使用的全可散式弹链 \nM33 FMJ \n每1%有5发子弹,最大500发 \n当你不再为子弹发愁,还有什么是解决不了的呢</entitydescription.berra_50bmg_belt_fmjt>
   <entitydescription.berra_mk153_dumb>Mk153 SMAW所使用的训练弹,与常规弹药有着完全一致的弹道 \n不过说真的,里面就是枚惰性弹头,你还指望它能干什么呢? \n尾焰喷射距离:4.4m</entitydescription.berra_mk153_dumb>
   <entitydescription.berra_mk153_inc>Mk153 SMAW所使用的燃烧弹,更重的弹体意味着能携带更多的燃料 \n现在是烧烤时间! \n尾焰喷射距离:4.4m</entitydescription.berra_mk153_inc>
@@ -407,7 +403,6 @@
   
   <talentdescription.rangedspreadreduction>你的远程武器散布降低[amount]%</talentdescription.rangedspreadreduction>
   <talentdescription.aimbetter>在瞄准时,你的远程武器散布降低[amount]%</talentdescription.aimbetter>
-  <talentdescription.dutyofcbrn>当你受到攻击,得到[affliction2] \n你在血量低于0时[time]秒内不会失去意识</talentdescription.dutyofcbrn>
   <talentdescription.nanomachine>在你的体内植入纳米机器人,提供[amount]%的毒药抗性</talentdescription.nanomachine>
   <talentdescription.nanomachineondamaged>当你的生命值低于[amount]%时,启用体内植入的纳米机器人进行修复  \n此效果将持续[time]秒</talentdescription.nanomachineondamaged>
   <talentdescription.maxtriggerinseconds>此效果在[seconds]秒内只能触发1次</talentdescription.maxtriggerinseconds>
@@ -615,4 +610,17 @@
   <entityname.uhm_headset>用户健康监控耳机</entityname.uhm_headset>
   <entitydescription.uhm_headset>内建有用户状态监控系统的耳机, 能在佩戴者昏迷时发送求救信号 \n需要电池</entitydescription.uhm_headset>
   <sig.sos>使用者状态危急 \n需要援助</sig.sos>
+
+  <entityname.uhm_headset_autoinjector>用户健康监控自注射耳机</entityname.uhm_headset_autoinjector>
+  <entitydescription.uhm_headset_autoinjector>内建有用户状态监控系统的自注射耳机, 能在佩戴者昏迷时发送求救信号 \n需要电池</entitydescription.uhm_headset_autoinjector>
+
+  <talentdescription.dutyofcbrn>当你受到攻击,得到[affliction1], 冷却时间为[cd1]和[affliction2], 冷却时间为[cd2] \n你在血量低于0时[time]秒内不会失去意识 \n在清醒期间不会死于收到的伤害</talentdescription.dutyofcbrn>
+  <talentvalue.berra_STANAG_50beowulf_fr_drum>PMAG-D60弹鼓 .50贝奥武夫易碎弹</talentvalue.berra_STANAG_50beowulf_fr_drum>
+  <talentvalue.berra_STANAG_50beowulf_ap_ext>STANAG弹匣(拓展) .50贝奥武夫穿甲弹</talentvalue.berra_STANAG_50beowulf_ap_ext>
+  <talentvalue.berra_M107Mag_m903>M82/M107通用弹匣 M903 SLAP</talentvalue.berra_M107Mag_m903>
+  <talentvalue.berra_M107Mag_mk211mod0>M82/M107通用弹匣 Mk211 Mod.0 APHEI</talentvalue.berra_M107Mag_mk211mod0>
+  <entitydescription.berra_STANAG_50beowulf_fr_ext>STANAG弹匣 \n内装20发.50贝奥武夫易碎弹 \n穿甲性能不佳,然而强大的停止力弥补了这一点</entitydescription.berra_STANAG_50beowulf_fr_ext>
+  <entitydescription.berra_STANAG_50beowulf_ap_ext>STANAG弹匣 \n内装20发.50贝奥武夫穿甲弹 \n高穿透力,高停止力,开创!</entitydescription.berra_STANAG_50beowulf_ap_ext>
+  <entitydescription.berra_STANAG_50beowulf_fr>STANAG弹匣 \n内装10发.50贝奥武夫易碎弹 \n穿甲性能不佳,然而强大的停止力弥补了这一点</entitydescription.berra_STANAG_50beowulf_fr>
+  <entitydescription.berra_STANAG_50beowulf_ap>STANAG弹匣 \n内装10发.50贝奥武夫穿甲弹 \n高穿透力,高停止力 </entitydescription.berra_STANAG_50beowulf_ap>
 </infotexts>

--- a/lua/Scripts/Shared/DronesShared.lua
+++ b/lua/Scripts/Shared/DronesShared.lua
@@ -6,7 +6,7 @@ Controllers = { }
 Hook.Add("Drone.control", "Drone.control", function(effect, deltaTime, item, targets, worldPosition)
     if targets == nil then return end
     local targetCharacter = targets[1]
-    if targetCharacter == nil or targetCharacter.IsPlayer or tostring(targetCharacter.SpeciesName) ~= "Cbrn_mech" then return end
+    if targetCharacter == nil or targetCharacter.IsPlayer then return end
     if effect.type == ActionType.OnUse then
         if SERVER then
             local usingCharacter = effect.user

--- a/material.xml
+++ b/material.xml
@@ -22,14 +22,8 @@
       <sprite texture="%ModDir:3278494407%/Misc/Material/containerplain.png" canbehiddenbyotherwearables="false" sourcerect="0,0,316,100" depth="0.55" limb="Torso" depthlimb="LeftArm" rotation="90" scale="0.25" origin="0.5,1.0" />
     </Wearable>
     <Throwable characterusable="false" canBeCombined="true" slots="RightHand+LeftHand" aimable="false" throwforce="2.0" aimpos="-10,-40" holdpos="-10,-40" holdangle="90" handle1="0,0" handle2="0,0" msg="ItemMsgPickUpSelect">
-      <StatusEffect type="OnImpact" target="This" condition="-10" disabledeltatime="true" />
-      <!--<StatusEffect type="OnBroken" target="This" duration="40">
-      <sound file="Content/Items/Tools/Sprayer.ogg" range="500.0" loop="true"/>
-    </StatusEffect>-->
-      <!--No. This is a empty one-->
       <StatusEffect type="OnBroken" target="This">
         <Remove />
-        <!--GOD, this is only a empty canister! WTF else do you want?A explosion?-->
       </StatusEffect>
     </Throwable>
   </Item>


### PR DESCRIPTION
Adjusted .50BMG Magazines fabricate requirements
Fixed empty canisters drop will lead to a unusable canister(50% LOL)
Add ability to reduce oxygenlow for all APRs(Except CBRN-3)
Enhanced .50BMG weapons(except M2) and ammo
Add recipe for UAV Controller
Add Autoinjector UHM Headset
Adjusted Recipe for .50BMG Magazines
Add recipe for .50Beowulf Extended AP magazines
Add recipe for .50Beowulf FR Drum
Allow UAV Controller to control(TEMP)
Adjusted .50Beowulf deconstruct output
Localization Update
Fixed wrong icon for DemoExpert
Changed effect for Duty Of CBRN
Changed effect for REVOLUTION